### PR TITLE
Implement auth with JWT

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,3 @@
 PORT=3000
 DATABASE_URL=postgresql://user:password@localhost:5432/app
+JWT_SECRET=change-me

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "@prisma/client": "^4.0.0"
+    "@prisma/client": "^4.0.0",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.22",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -9,7 +9,7 @@ app.use(cors());
 app.use(express.json());
 app.use(setTenant);
 
-app.use('/auth', authRoutes);
+app.use('/api/auth', authRoutes);
 app.use('/tenant', tenantRoutes);
 
 export default app;

--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -1,6 +1,22 @@
-export function requireAuth(req, res, next) {
-  if (!req.headers.authorization) {
+import jwt from 'jsonwebtoken';
+import prisma from '../prisma/client.js';
+
+export async function requireAuth(req, res, next) {
+  const auth = req.headers.authorization || '';
+  if (!auth.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  next();
+
+  const token = auth.replace('Bearer ', '');
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await prisma.user.findUnique({ where: { id: payload.userId } });
+    if (!user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    req.user = user;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
 }

--- a/backend/src/prisma/client.js
+++ b/backend/src/prisma/client.js
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -10,5 +10,6 @@ generator client {
 model User {
   id    Int    @id @default(autoincrement())
   email String @unique
+  password String
   name  String?
 }

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -1,13 +1,52 @@
 import { Router } from 'express';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import prisma from '../prisma/client.js';
 
 const router = Router();
 
-router.post('/login', (req, res) => {
-  res.json({ token: 'fake-token' });
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET, {
+    expiresIn: '1h'
+  });
+  res.json({ token });
 });
 
-router.post('/signup', (req, res) => {
-  res.json({ id: 1 });
+router.post('/signup', async (req, res) => {
+  const { email, password, name } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password required' });
+  }
+
+  try {
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({
+      data: { email, password: hashed, name }
+    });
+
+    res.json({ id: user.id });
+  } catch (err) {
+    if (err.code === 'P2002') {
+      return res.status(400).json({ error: 'Email already exists' });
+    }
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- add password column in Prisma schema
- support JWT_SECRET env var
- mount auth router at `/api/auth`
- implement signup/login routes with bcrypt and JWT
- add JWT authentication middleware
- include Prisma client helper

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cc55651108322abffcfebf7a8554a