### PR TITLE
Implement /api/me route

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import authRoutes from './routes/auth.routes.js';
 import tenantRoutes from './routes/tenant.routes.js';
+import userRoutes from './routes/user.routes.js';
 import { setTenant } from './middleware/tenant.middleware.js';
 
 const app = express();
@@ -11,5 +12,6 @@ app.use(setTenant);
 
 app.use('/api/auth', authRoutes);
 app.use('/tenant', tenantRoutes);
+app.use('/api', userRoutes);
 
 export default app;

--- a/backend/src/prisma/schema.prisma
+++ b/backend/src/prisma/schema.prisma
@@ -12,4 +12,12 @@ model User {
   email String @unique
   password String
   name  String?
+  tenantId Int?
+  tenant   Tenant? @relation(fields: [tenantId], references: [id])
+}
+
+model Tenant {
+  id    Int    @id @default(autoincrement())
+  name  String
+  users User[]
 }

--- a/backend/src/routes/user.routes.js
+++ b/backend/src/routes/user.routes.js
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth.middleware.js';
+import prisma from '../prisma/client.js';
+
+const router = Router();
+
+router.get('/me', requireAuth, async (req, res) => {
+  try {
+    const userWithTenant = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      include: { tenant: true }
+    });
+    if (!userWithTenant) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    const { password, ...user } = userWithTenant;
+    res.json({ user, tenant: userWithTenant.tenant });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- define Tenant model and relation to User in Prisma schema
- add protected `/api/me` route
- register new route in `app.js`

## Testing
- `npx prisma generate --schema=src/prisma/schema.prisma`
- `npm --workspace backend run --silent dev` *(fails: [object])*


------
https://chatgpt.com/codex/tasks/task_e_688cc6eb4bac8322bebc954583a1f19e