### PR TITLE
Implement login flow in frontend

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,3 +1,73 @@
+import { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import api from '../api/axios';
+
 export default function Login() {
-  return <div>Login Page</div>;
+  const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+
+    try {
+      const res = await api.post('/api/auth/login', { email, password });
+      const { token } = res.data;
+      login(token);
+      navigate('/dashboard');
+    } catch (err) {
+      const msg = err.response?.data?.error || 'Login failed';
+      setError(msg);
+    }
+  };
+
+  return (
+    <div className="flex justify-center mt-10">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4"
+      >
+        <div className="mb-4">
+          <label className="block text-gray-700 text-sm font-bold mb-2">
+            Email
+          </label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          />
+        </div>
+        <div className="mb-6">
+          <label className="block text-gray-700 text-sm font-bold mb-2">
+            Password
+          </label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
+          />
+        </div>
+        {error && (
+          <p className="text-red-500 text-xs italic mb-4" data-testid="login-error">
+            {error}
+          </p>
+        )}
+        <div className="flex items-center justify-between">
+          <button
+            type="submit"
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          >
+            Sign In
+          </button>
+        </div>
+      </form>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- implement login form and API call
- store JWT in localStorage via AuthContext
- redirect to dashboard after login
- show error messages on failed login

## Testing
- `npm run build --workspace=frontend`

------
https://chatgpt.com/codex/tasks/task_e_688cc896c2ac8322bdf179e7c49bba15