### PR TITLE
Refactor domain creation to use env

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 PORT=3000
 DATABASE_URL=postgresql://user:password@localhost:5432/app
 JWT_SECRET=change-me
+APP_BASE_DOMAIN=myapp.com

--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -45,7 +45,8 @@ router.post('/signup', async (req, res) => {
     const hashed = await bcrypt.hash(password, 10);
 
     const slug = slugify(company);
-    const domain = `${slug}.myapp.com`;
+    const baseDomain = process.env.APP_BASE_DOMAIN;
+    const domain = `${slug}.${baseDomain}`;
 
     let tenant = await prisma.tenant.findUnique({ where: { slug } });
     if (!tenant) {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,3 +1,5 @@
+import dotenv from 'dotenv';
+dotenv.config();
 import app from './app.js';
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- configure `APP_BASE_DOMAIN` in backend `.env.example`
- use `APP_BASE_DOMAIN` when computing tenant domains
- load environment variables in backend server startup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ccbb458b08322b490be3bdea4951d