### PR TITLE
Document APP_BASE_DOMAIN usage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 PORT=3000
 DATABASE_URL=postgresql://user:password@localhost:5432/app
 JWT_SECRET=change-me
+# Base domain used to create tenant-specific subdomains, e.g. tenant1.mycompany.com
 APP_BASE_DOMAIN=myapp.com

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,3 +12,9 @@ Simple Express API using Prisma as ORM.
    ```bash
    npm run dev
    ```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and update the values as needed. In particular,
+`APP_BASE_DOMAIN` defines the base domain used when generating tenant-specific
+subdomains (for example `tenant1.mycompany.com`).


### PR DESCRIPTION
## Summary
- comment APP_BASE_DOMAIN in backend `.env.example`
- document new variable in backend README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cce89cafc832291f51095cbd6458b