### PR TITLE
Add Swagger JSDoc configuration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "swagger-jsdoc": "^6.2.8"
   },
   "devDependencies": {
     "nodemon": "^2.0.22",

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -1,0 +1,22 @@
+import swaggerJSDoc from 'swagger-jsdoc';
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'SaaS API',
+      version: '1.0.0',
+    },
+    servers: [
+      {
+        url: 'http://localhost:3000',
+      },
+    ],
+  },
+  apis: ['./src/routes/*.js'],
+};
+
+const swaggerSpec = swaggerJSDoc(options);
+
+export default swaggerSpec;
+


### PR DESCRIPTION
## Summary
- configure Swagger JSDoc spec for SaaS API and scan route files
- add `swagger-jsdoc` dependency for backend

## Testing
- `npm test -w backend` *(fails: Missing script "test" )*
- `npm install -w backend swagger-jsdoc` *(fails: 403 Forbidden - GET https://registry.npmjs.org/swagger-jsdoc)*

------
https://chatgpt.com/codex/tasks/task_e_688dcf3db4bc83229521e19733d74d0e