### PR TITLE
feat: expose Swagger UI at /api/docs

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "dotenv": "^17.2.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
-    "swagger-jsdoc": "^6.2.8"
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {
     "nodemon": "^2.0.22",

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,6 +1,10 @@
 import dotenv from 'dotenv';
 dotenv.config();
 import app from './app.js';
+import swaggerUi from 'swagger-ui-express';
+import swaggerSpec from './swagger.js';
+
+app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- serve autogenerated API docs at `/api/docs`
- add Swagger UI dependency

## Testing
- `npm test --workspace=backend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688dde03f8e08322925b2860a45922b7