### PR TITLE
docs: update signup swagger to require first and last name

### DIFF
--- a/backend/src/routes/auth.routes.js
+++ b/backend/src/routes/auth.routes.js
@@ -82,6 +82,7 @@ function slugify(str) {
  * /api/auth/signup:
  *   post:
  *     summary: Create a new user
+ *     description: Requires email, password, company, first name, and last name
  *     tags: ['Auth']
  *     requestBody:
  *       required: true
@@ -98,14 +99,19 @@ function slugify(str) {
  *             properties:
  *               email:
  *                 type: string
+ *                 description: User's email address
  *               password:
  *                 type: string
+ *                 description: User's password
  *               company:
  *                 type: string
+ *                 description: Company name
  *               firstName:
  *                 type: string
+ *                 description: User's first name
  *               lastName:
  *                 type: string
+ *                 description: User's last name
  *     responses:
  *       201:
  *         description: User created


### PR DESCRIPTION
## Summary
- document required signup fields with first and last name
- describe signup fields for better Swagger docs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688df0e72c788322a16c356dabf86cfe