### PR TITLE
Split signup full name into first and last name fields

### DIFF
--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -7,7 +7,8 @@ export default function Signup() {
   const navigate = useNavigate();
   const { login } = useContext(AuthContext);
 
-  const [name, setName] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [company, setCompany] = useState('');
@@ -18,7 +19,8 @@ export default function Signup() {
     setError('');
     try {
       const res = await api.post('/api/auth/signup', {
-        name,
+        firstName,
+        lastName,
         email,
         password,
         company
@@ -39,11 +41,20 @@ export default function Signup() {
         className="w-full max-w-sm bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4"
       >
         <div className="mb-4">
-          <label className="block text-gray-700 text-sm font-bold mb-2">Full Name</label>
+          <label className="block text-gray-700 text-sm font-bold mb-2">First Name</label>
           <input
             type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-gray-700 text-sm font-bold mb-2">Last Name</label>
+          <input
+            type="text"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
             className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
           />
         </div>


### PR DESCRIPTION
## Summary
- replace single name field with first and last name inputs on the signup page
- send `firstName` and `lastName` to `/api/auth/signup`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688df12ac52083229ba361265f56a981